### PR TITLE
Add suffixes to excap survival boxes

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
+++ b/Resources/Prototypes/Catalog/Fills/Boxes/emergency.yml
@@ -22,6 +22,7 @@
   parent: BoxCardboard
   id: BoxSurvivalEngineering
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
+  suffix: Engineering
   components:
   - type: StorageFill
     contents:
@@ -106,6 +107,7 @@
   parent: BoxCardboard
   id: BoxSurvivalSyndicate
   description: It's a box with basic internals inside. This one is labelled to contain an extended-capacity tank.
+  suffix: Syndicate
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->

Adds two missing suffixes to the extended capacity survival boxes.

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

Because it irked me. What more motivation is necessary?

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

No.